### PR TITLE
Build fixes and safer Wine setup

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,7 @@ opt_in_rules:
 
 excluded:
   - .build
+  - WhiskyKit/.build
 
 file_header:
     severity: error

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
   [![macOS](https://img.shields.io/badge/macOS-14.0%2B-blue)](https://www.apple.com/macos/)
   [![Apple Silicon](https://img.shields.io/badge/Apple%20Silicon-M1%2FM2%2FM3%2FM4-green)](https://support.apple.com/en-us/116943)
-  [![Wine](https://img.shields.io/badge/Wine-Staging%2011.2-purple)](https://github.com/Gcenx/macOS_Wine_builds)
+  [![Wine](https://img.shields.io/badge/Wine-Staging%2011.10-purple)](https://github.com/Gcenx/macOS_Wine_builds)
   [![License](https://img.shields.io/badge/License-GPL--3.0-orange)](LICENSE)
 
   Forked from [Whisky-App/Whisky](https://github.com/Whisky-App/Whisky) (archived May 2025)
@@ -19,9 +19,9 @@ Moonshine is a maintained fork of Whisky, a native SwiftUI wrapper for Wine on m
 
 ## What's different from Whisky?
 
-- **Wine Staging 11.2** (Feb 2026) — replaces the outdated CrossOver 22.1.1 (2023) bundled with the original
+- **Wine Staging 11.10** — replaces the outdated CrossOver 22.1.1 (2023) bundled with the original
 - **Crash logs that actually work** — Wine output is captured in full, including page faults, DLL load failures, and exit codes
-- **OpenGL 3.2+ support** — binary patch to Wine's macOS driver fixes context creation for SDL3 and other modern engines
+- **OpenGL 3.2+ patch** — binary patch to Wine's macOS driver fixes context creation for SDL3 and other modern engines (offset was derived for 11.2; needs re-deriving for 11.10, see changelog)
 - **macOS 26 tested** — verified on the latest macOS with Apple Silicon
 
 ## System Requirements
@@ -39,7 +39,7 @@ Moonshine is a maintained fork of Whisky, a native SwiftUI wrapper for Wine on m
 1. Download `Moonshine.dmg` from the [latest release](https://github.com/ybmeng/moonshine/releases/latest)
 2. Open the DMG and drag **Moonshine.app** to **Applications**
 3. Launch the app — the setup wizard will automatically:
-   - Download [Wine Staging 11.2](https://github.com/Gcenx/macOS_Wine_builds/releases/tag/11.2) from Gcenx
+   - Download [Wine Staging 11.10](https://github.com/Gcenx/macOS_Wine_builds/releases/tag/11.10) from Gcenx
    - Extract and install Wine into the correct directory structure
    - Apply the OpenGL 3.2+ patch to `winemac.so`
 4. Create a bottle and start running Windows programs
@@ -68,7 +68,7 @@ The script will:
 5. Copy `Moonshine.app` to `/Applications`
 6. Launch the app
 
-On first launch, the setup wizard auto-downloads Wine Staging 11.2 and applies the OpenGL patch — same as Method 1.
+On first launch, the setup wizard auto-downloads Wine Staging 11.10 and applies the OpenGL patch — same as Method 1.
 
 ### Build a DMG
 
@@ -93,6 +93,14 @@ Each run creates a timestamped log with full Wine output, including crash detail
 ---
 
 ## Changelog (from upstream Whisky v2.3.5)
+
+### v2.7.1-fork — Fix Wine download (404) and setup robustness
+
+**Problem:** The pinned Wine version `11.2` does not exist on Gcenx — its releases are `11.10, 11.9, 11.8, …`. So the auto-download always returned a 404 and setup could never complete. The download screen also ignored errors, leaving the wizard stuck on a progress bar.
+
+**Solution:** Pin Wine Staging **11.10** (a real release) and surface download failures with a retry/quit dialog. The SemanticVersion package dependency was also switched from an SSH to an HTTPS URL so the project builds without GitHub SSH keys, and the leftover upstream Wine update check is disabled so it can't replace the pinned build.
+
+**Known follow-up:** the OpenGL `winemac.so` patch offset (`0x329fb`) was derived for the 11.2 build and no longer matches 11.10, so it is safely skipped until re-derived. D3D/Vulkan rendering is unaffected; only OpenGL 3.2+ games are.
 
 ### v2.7.0-fork — DMG distribution with auto-download Wine setup
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Moonshine is a maintained fork of Whisky, a native SwiftUI wrapper for Wine on m
 
 - **Wine Staging 11.10** — replaces the outdated CrossOver 22.1.1 (2023) bundled with the original
 - **Crash logs that actually work** — Wine output is captured in full, including page faults, DLL load failures, and exit codes
-- **OpenGL 3.2+ patch** — binary patch to Wine's macOS driver fixes context creation for SDL3 and other modern engines (offset was derived for 11.2; needs re-deriving for 11.10, see changelog)
+- **OpenGL 3.2+ patch** — binary patch to Wine's macOS driver fixes context creation for SDL3 and other modern engines (re-derived for the 11.10 build, offset `0x319cb`)
 - **macOS 26 tested** — verified on the latest macOS with Apple Silicon
 
 ## System Requirements
@@ -100,7 +100,7 @@ Each run creates a timestamped log with full Wine output, including crash detail
 
 **Solution:** Pin Wine Staging **11.10** (a real release) and surface download failures with a retry/quit dialog. The SemanticVersion package dependency was also switched from an SSH to an HTTPS URL so the project builds without GitHub SSH keys, and the leftover upstream Wine update check is disabled so it can't replace the pinned build.
 
-**Known follow-up:** the OpenGL `winemac.so` patch offset (`0x329fb`) was derived for the 11.2 build and no longer matches 11.10, so it is safely skipped until re-derived. D3D/Vulkan rendering is unaffected; only OpenGL 3.2+ games are.
+**OpenGL patch re-derived:** the `winemac.so` patch offset (`0x329fb`) was derived for the 11.2 build and pointed at an unrelated byte on 11.10, so the installer's safety guard skipped it and OpenGL 3.2+ context creation stayed broken. Disassembled the 11.10 build and found the same `test al,al; je` forward-compatible guard in `create_context` at offset `0x319cb` (`0x74` `je` → `0xeb` `jmp`); `WhiskyWineInstaller.swift` now patches there, and the byte-value guard still skips safely on any other build.
 
 ### v2.7.0-fork — DMG distribution with auto-download Wine setup
 

--- a/Whisky/Localizable.xcstrings
+++ b/Whisky/Localizable.xcstrings
@@ -1497,6 +1497,16 @@
         }
       }
     },
+    "button.cancel" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
     "button.removeAlert.cancel" : {
       "localizations" : {
         "ar" : {
@@ -17138,6 +17148,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "讓我們為你完成設置。此步驟不會花上一分鐘時間。"
+          }
+        }
+      }
+    },
+    "setup.whiskywine.download.failed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wine download failed"
+          }
+        }
+      }
+    },
+    "setup.whiskywine.download.httpError" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The server returned HTTP status %d. Wine could not be downloaded."
+          }
+        }
+      }
+    },
+    "setup.whiskywine.download.noFile" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The download completed but no file was received."
+          }
+        }
+      }
+    },
+    "setup.whiskywine.download.retry" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
           }
         }
       }

--- a/Whisky/Views/Setup/WhiskyWineDownloadView.swift
+++ b/Whisky/Views/Setup/WhiskyWineDownloadView.swift
@@ -64,39 +64,61 @@ struct WhiskyWineDownloadView: View {
         }
         .frame(width: 400, height: 200)
         .onAppear {
+            startDownload()
+        }
+    }
+
+    @MainActor
+    func startDownload() {
+        observation?.invalidate()
+        fractionProgress = 0
+        completedBytes = 0
+        totalBytes = 0
+        let wineURL = "https://github.com/Gcenx/macOS_Wine_builds/"
+            + "releases/download/11.2/wine-staging-11.2-osx64.tar.xz"
+        guard let url = URL(string: wineURL) else { return }
+
+        downloadTask = URLSession(configuration: .ephemeral)
+            .downloadTask(with: url) { localURL, response, error in
+                Task.detached {
+                    await MainActor.run {
+                        if let error = error {
+                            showDownloadError(error.localizedDescription)
+                            return
+                        }
+                        if let httpResponse = response as? HTTPURLResponse,
+                           !(200...299).contains(httpResponse.statusCode) {
+                            showDownloadError(String(
+                                format: String(localized: "setup.whiskywine.download.httpError"),
+                                httpResponse.statusCode
+                            ))
+                            return
+                        }
+                        guard let localURL = localURL else {
+                            showDownloadError(String(localized: "setup.whiskywine.download.noFile"))
+                            return
+                        }
+                        tarLocation = localURL
+                        proceed()
+                    }
+                }
+            }
+        observation = downloadTask?.observe(\.countOfBytesReceived) { task, _ in
             Task {
-                let wineURL = "https://github.com/Gcenx/macOS_Wine_builds/"
-                    + "releases/download/11.2/wine-staging-11.2-osx64.tar.xz"
-                if let url: URL = URL(string: wineURL) {
-                    downloadTask = URLSession(configuration: .ephemeral).downloadTask(with: url) { url, _, _ in
-                        Task.detached {
-                            await MainActor.run {
-                                if let url = url {
-                                    tarLocation = url
-                                    proceed()
-                                }
-                            }
-                        }
+                await MainActor.run {
+                    let currentTime = Date()
+                    let elapsedTime = currentTime.timeIntervalSince(startTime ?? currentTime)
+                    if completedBytes > 0 {
+                        downloadSpeed = Double(completedBytes) / elapsedTime
                     }
-                    observation = downloadTask?.observe(\.countOfBytesReceived) { task, _ in
-                        Task {
-                            await MainActor.run {
-                                let currentTime = Date()
-                                let elapsedTime = currentTime.timeIntervalSince(startTime ?? currentTime)
-                                if completedBytes > 0 {
-                                    downloadSpeed = Double(completedBytes) / elapsedTime
-                                }
-                                totalBytes = task.countOfBytesExpectedToReceive
-                                completedBytes = task.countOfBytesReceived
-                                fractionProgress = Double(completedBytes) / Double(totalBytes)
-                            }
-                        }
-                    }
-                    startTime = Date()
-                    downloadTask?.resume()
+                    totalBytes = task.countOfBytesExpectedToReceive
+                    completedBytes = task.countOfBytesReceived
+                    fractionProgress = Double(completedBytes) / Double(totalBytes)
                 }
             }
         }
+        startTime = Date()
+        downloadTask?.resume()
     }
 
     func formatBytes(bytes: Int64) -> String {
@@ -126,5 +148,22 @@ struct WhiskyWineDownloadView: View {
 
     func proceed() {
         path.append(.whiskyWineInstall)
+    }
+
+    @MainActor
+    func showDownloadError(_ message: String) {
+        observation?.invalidate()
+        let alert = NSAlert()
+        alert.messageText = String(localized: "setup.whiskywine.download.failed")
+        alert.informativeText = message
+        alert.alertStyle = .critical
+        alert.addButton(withTitle: String(localized: "setup.whiskywine.download.retry"))
+        alert.addButton(withTitle: String(localized: "button.cancel"))
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            startDownload()
+        } else {
+            NSApplication.shared.terminate(nil)
+        }
     }
 }

--- a/Whisky/Views/Setup/WhiskyWineDownloadView.swift
+++ b/Whisky/Views/Setup/WhiskyWineDownloadView.swift
@@ -75,7 +75,7 @@ struct WhiskyWineDownloadView: View {
         completedBytes = 0
         totalBytes = 0
         let wineURL = "https://github.com/Gcenx/macOS_Wine_builds/"
-            + "releases/download/11.2/wine-staging-11.2-osx64.tar.xz"
+            + "releases/download/11.10/wine-staging-11.10-osx64.tar.xz"
         guard let url = URL(string: wineURL) else { return }
 
         downloadTask = URLSession(configuration: .ephemeral)

--- a/WhiskyKit/Package.resolved
+++ b/WhiskyKit/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "semanticversion",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:SwiftPackageIndex/SemanticVersion.git",
+      "location" : "https://github.com/SwiftPackageIndex/SemanticVersion.git",
       "state" : {
         "revision" : "45e2ec89fee3b76cd6dde3f9a507e4348f194b79",
         "version" : "0.3.7"

--- a/WhiskyKit/Package.swift
+++ b/WhiskyKit/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         )
     ],
     dependencies: [
-      .package(url: "git@github.com:SwiftPackageIndex/SemanticVersion.git", from: "0.3.0")
+      .package(url: "https://github.com/SwiftPackageIndex/SemanticVersion.git", from: "0.3.0")
     ],
     targets: [
         .target(

--- a/WhiskyKit/Package.swift
+++ b/WhiskyKit/Package.swift
@@ -37,6 +37,10 @@ let package = Package(
         .target(
             name: "WhiskyKit",
             dependencies: ["SemanticVersion"]
+        ),
+        .testTarget(
+            name: "WhiskyKitTests",
+            dependencies: ["WhiskyKit", "SemanticVersion"]
         )
     ],
     swiftLanguageVersions: [.version("6")]

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
@@ -71,7 +71,7 @@ public class WhiskyWineInstaller {
             let versionPlist = libraryFolder
                 .appending(path: "WhiskyWineVersion")
                 .appendingPathExtension("plist")
-            let versionInfo = WhiskyWineVersion(version: SemanticVersion(11, 2, 0))
+            let versionInfo = WhiskyWineVersion(version: SemanticVersion(11, 10, 0))
             let encoder = PropertyListEncoder()
             encoder.outputFormat = .xml
             let data = try encoder.encode(versionInfo)
@@ -84,8 +84,8 @@ public class WhiskyWineInstaller {
         }
     }
 
-    /// Patches winemac.so to enable OpenGL 3.2+ context creation for SDL3-based games.
-    /// Changes byte at offset 0x329fb from 0x74 (JE) to 0xEB (JMP).
+    /// Patches winemac.so for OpenGL 3.2+ context creation (0x329fb: 0x74 JE -> 0xEB JMP).
+    /// Offset was derived from the 11.2 build; on other builds the guard below skips it safely.
     private static func applyOpenGLPatch() {
         let winemacPath = libraryFolder
             .appending(path: "Wine")
@@ -134,10 +134,7 @@ public class WhiskyWineInstaller {
     }
 
     public static func shouldUpdateWhiskyWine() async -> (Bool, SemanticVersion) {
-        // Moonshine pins Wine Staging 11.2 from Gcenx. The upstream update feed
-        // (data.getwhisky.app) serves the original CrossOver-based build, so honoring
-        // it would uninstall the pinned Wine + OpenGL patch and replace it with the
-        // wrong binaries. Disable the remote update check entirely.
+        // Disabled: the upstream feed serves the original Wine, which would replace our pinned build.
         return (false, SemanticVersion(0, 0, 0))
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
@@ -134,41 +134,10 @@ public class WhiskyWineInstaller {
     }
 
     public static func shouldUpdateWhiskyWine() async -> (Bool, SemanticVersion) {
-        let versionPlistURL = "https://data.getwhisky.app/Wine/WhiskyWineVersion.plist"
-        let localVersion = whiskyWineVersion()
-
-        var remoteVersion: SemanticVersion?
-
-        if let remoteUrl = URL(string: versionPlistURL) {
-            remoteVersion = await withCheckedContinuation { continuation in
-                URLSession(configuration: .ephemeral).dataTask(with: URLRequest(url: remoteUrl)) { data, _, error in
-                    do {
-                        if error == nil, let data = data {
-                            let decoder = PropertyListDecoder()
-                            let remoteInfo = try decoder.decode(WhiskyWineVersion.self, from: data)
-                            let remoteVersion = remoteInfo.version
-
-                            continuation.resume(returning: remoteVersion)
-                            return
-                        }
-                        if let error = error {
-                            print(error)
-                        }
-                    } catch {
-                        print(error)
-                    }
-
-                    continuation.resume(returning: nil)
-                }.resume()
-            }
-        }
-
-        if let localVersion = localVersion, let remoteVersion = remoteVersion {
-            if localVersion < remoteVersion {
-                return (true, remoteVersion)
-            }
-        }
-
+        // Moonshine pins Wine Staging 11.2 from Gcenx. The upstream update feed
+        // (data.getwhisky.app) serves the original CrossOver-based build, so honoring
+        // it would uninstall the pinned Wine + OpenGL patch and replace it with the
+        // wrong binaries. Disable the remote update check entirely.
         return (false, SemanticVersion(0, 0, 0))
     }
 

--- a/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
+++ b/WhiskyKit/Sources/WhiskyKit/WhiskyWine/WhiskyWineInstaller.swift
@@ -84,8 +84,11 @@ public class WhiskyWineInstaller {
         }
     }
 
-    /// Patches winemac.so for OpenGL 3.2+ context creation (0x329fb: 0x74 JE -> 0xEB JMP).
-    /// Offset was derived from the 11.2 build; on other builds the guard below skips it safely.
+    /// Patches winemac.so so OpenGL 3.2+ core contexts are accepted even when the app does not
+    /// request the forward-compatible flag (winemac.drv otherwise rejects them with
+    /// ERROR_INVALID_VERSION_ARB). Flips the `test al,al; je` guard to an unconditional jump
+    /// (0x319cb: 0x74 JE -> 0xEB JMP). Offset is for the pinned 11.10 build; on other builds the
+    /// guard below skips it safely.
     private static func applyOpenGLPatch() {
         let winemacPath = libraryFolder
             .appending(path: "Wine")
@@ -103,7 +106,7 @@ public class WhiskyWineInstaller {
             let fileHandle = try FileHandle(forUpdating: winemacPath)
             defer { fileHandle.closeFile() }
 
-            let patchOffset: UInt64 = 0x329fb
+            let patchOffset: UInt64 = 0x319cb
             fileHandle.seek(toFileOffset: patchOffset)
 
             guard let currentByte = fileHandle.readData(ofLength: 1).first else {

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
@@ -21,9 +21,6 @@ import SemanticVersion
 @testable import WhiskyKit
 
 final class WhiskyWineInstallerTests: XCTestCase {
-    /// Moonshine pins Gcenx Wine Staging 11.2, so the upstream update check must be
-    /// disabled — otherwise it would uninstall the pinned Wine and re-run setup against
-    /// the wrong (CrossOver-based) feed.
     func testUpstreamUpdateCheckIsDisabled() async {
         let (shouldUpdate, version) = await WhiskyWineInstaller.shouldUpdateWhiskyWine()
         XCTAssertFalse(shouldUpdate, "Upstream Wine auto-update must stay disabled for the Gcenx-pinned fork")

--- a/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
+++ b/WhiskyKit/Tests/WhiskyKitTests/WhiskyWineInstallerTests.swift
@@ -1,0 +1,32 @@
+//
+//  WhiskyWineInstallerTests.swift
+//  WhiskyKitTests
+//
+//  This file is part of Whisky.
+//
+//  Whisky is free software: you can redistribute it and/or modify it under the terms
+//  of the GNU General Public License as published by the Free Software Foundation,
+//  either version 3 of the License, or (at your option) any later version.
+//
+//  Whisky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+//  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//  See the GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License along with Whisky.
+//  If not, see https://www.gnu.org/licenses/.
+//
+
+import XCTest
+import SemanticVersion
+@testable import WhiskyKit
+
+final class WhiskyWineInstallerTests: XCTestCase {
+    /// Moonshine pins Gcenx Wine Staging 11.2, so the upstream update check must be
+    /// disabled — otherwise it would uninstall the pinned Wine and re-run setup against
+    /// the wrong (CrossOver-based) feed.
+    func testUpstreamUpdateCheckIsDisabled() async {
+        let (shouldUpdate, version) = await WhiskyWineInstaller.shouldUpdateWhiskyWine()
+        XCTAssertFalse(shouldUpdate, "Upstream Wine auto-update must stay disabled for the Gcenx-pinned fork")
+        XCTAssertEqual(version, SemanticVersion(0, 0, 0))
+    }
+}


### PR DESCRIPTION
A few fixes from working through the setup flow on a fresh machine.

## What
- Pin Wine Staging 11.10 instead of 11.2.
- Switch the SemanticVersion package dependency from an SSH URL to HTTPS.
- Turn off the leftover "update WhiskyWine" check that points at the old upstream server.
- Show an error with a Retry button if the Wine download fails during first-run setup, instead of just hanging.
- Stop SwiftLint from linting the nested `WhiskyKit/.build` (downloaded SPM dependencies).
- Re-derive the OpenGL winemac.so patch offset for the 11.10 build (0x329fb → 0x319cb).

## Why
- The pinned version 11.2 doesn't exist on Gcenx (their releases are 11.10, 11.9, 11.8, ...), so the auto-download always 404'd and setup could never finish. 11.10 is a real release.
- The SSH URL meant the project wouldn't build unless you had GitHub SSH keys set up — CI and fresh clones just failed.
- The update check pointed at upstream Whisky's server, which serves the old CrossOver-based Wine. If it ever offered an update, accepting it would wipe the pinned Wine build and replace it with the wrong thing.
- The download screen ignored network and HTTP errors, so a failed download left the wizard stuck on a progress bar with no way out.
- Once you build WhiskyKit locally, SwiftLint picked up the dependency checkouts under `WhiskyKit/.build` and failed the whole build on third-party violations.
- The OpenGL patch offset (0x329fb) was derived for 11.2 and pointed at an unrelated byte on 11.10, so the patch silently skipped and OpenGL 3.2+ context creation stayed broken.

## How it helps
- Setup completes instead of 404-ing on the download.
- Anyone can build straight after cloning — no SSH setup, and the local DMG/source build no longer trips over dependency lint.
- The pinned Wine build stays put.
- A failed download tells you what happened and lets you retry instead of silently hanging.
- OpenGL 3.2+ core contexts that don't request the forward-compatible flag are accepted again, so OpenGL games work on the pinned 11.10 build.

## The OpenGL patch
winemac.drv rejects 3.2+ core contexts that aren't forward-compatible (ERROR_INVALID_VERSION_ARB), but most apps request a core context without that flag. The patch flips the `test al,al; je` guard in `create_context` to an unconditional jump so creation always proceeds. On 11.10 that instruction lives at offset 0x319cb (verified `0x74` JE → `0xEB` JMP); the byte-value guard still skips safely on any other build.

## Testing
Added a small WhiskyKit test target with a first test covering the disabled update check (run with `swift test`).
